### PR TITLE
Fix variant dialog not showing in AS 4.2

### DIFF
--- a/src/main/java/com/android/tools/idea/gradle/project/model/NdkModuleModel.kt
+++ b/src/main/java/com/android/tools/idea/gradle/project/model/NdkModuleModel.kt
@@ -1,0 +1,14 @@
+package com.android.tools.idea.gradle.project.model
+
+fun NdkModuleModel.fetchVariantNames() : Collection<String?> {
+    return try {
+        ndkVariantNames
+    } catch (_: NoSuchMethodError) {
+        // Method is no longer accessible so try to get it via reflection
+        val variants = javaClass.methods.find { it.name == "getAllVariantAbis" }?.invoke(this) as? Set<*>
+        //  This is a set of AbiVariant, which is not visible either, so find the right field with the name property
+        variants
+            ?.filterNotNull()
+            ?.map { it.javaClass.getMethod("getVariant").invoke(it) } as? Collection<String?> ?: emptySet()
+    }
+}

--- a/src/main/java/com/pandora/plugin/actions/SwitchBuildVariant.kt
+++ b/src/main/java/com/pandora/plugin/actions/SwitchBuildVariant.kt
@@ -3,6 +3,7 @@ package com.pandora.plugin.actions
 import com.android.tools.idea.gradle.project.ProjectStructure
 import com.android.tools.idea.gradle.project.model.AndroidModuleModel
 import com.android.tools.idea.gradle.project.model.NdkModuleModel
+import com.android.tools.idea.gradle.project.model.fetchVariantNames
 import com.android.tools.idea.gradle.variant.view.BuildVariantUpdater
 import com.android.tools.idea.gradle.variant.view.update
 import com.intellij.openapi.actionSystem.AnAction
@@ -45,10 +46,10 @@ class SwitchBuildVariant : AnAction() {
     }
 
     private val Module.variantNames: Collection<String?>
-        get() = NdkModuleModel.get(this)?.ndkVariantNames ?: AndroidModuleModel.get(this)?.variantNames ?: emptyList()
+        get() = NdkModuleModel.get(this)?.fetchVariantNames() ?: AndroidModuleModel.get(this)?.variantNames ?: emptyList()
 
     private val Module.variantItems: ModuleBuildVariant
-        get() = ModuleBuildVariant(name, variantNames.asSequence().filterNotNull().sorted().toList())
+        get() = ModuleBuildVariant(name, variantNames.asSequence().distinct().filterNotNull().sorted().toList())
 
     private data class ModuleBuildVariant(val moduleName: String, val buildVariants: List<String>)
 }


### PR DESCRIPTION
This is a fix for #5. It relies heavily on reflection for two main reasons:
1. `ndkVariantNames` is no longer visible and the only accessible method of interest is `getAllVariantAbis`
2. `getVariantAbis` returns Set<[VariantAbi](https://cs.android.com/android-studio/platform/tools/adt/idea/+/refs/tags/studio-4.2.0:android/src/com/android/tools/idea/gradle/project/model/VariantAbi.kt)> which is not visible either, so the `name` field has to be reflectively accessed as well.

There's one tiny change as well to reduce duplication by adding a call to `distinct()` when getting variant names. I'm happy to split this into a separate PR if necessary.